### PR TITLE
Always show phan errors (when syntactically valid)

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,16 +23,7 @@
 
 * Usage
 
-** Compilation mode
-
-   See the Flycheck checker section.
-   TODO: re-enable running phan against a directory
-
 ** Flycheck checker
-
-   This is more an experiment than a production feature. 
-   Flycheck should not be used to perform such heavy tasks.
-   The request frequency likely needs to be tuned.
 
    First, load the flycheck checker:
 
@@ -46,6 +37,9 @@
    (e.g. ~.dir-locals.el~)
 
    This should be enough to have the flycheck checker run on your project.
+   This will run while the project is being edited, even without saving the file.
+
+   Note: The request frequency may still need to be tuned for larger projects.
 
 * Configuration
 

--- a/flycheck-phanclient.el
+++ b/flycheck-phanclient.el
@@ -8,20 +8,23 @@
 ;;; Code:
 (require 'flycheck)
 
+;; TODO: Use phan's severity level to choose between warning and info. Include that in the lines printed by phan_client.
+;; TODO: Allow users to override the information included in message?
+
 (flycheck-define-checker php-phanclient
   "A PHP static analyzer using phan. Analyzes the file on buffer save.
 
 See URL `https://github.com/etsy/phan'."
-  :command ("phan_client" "-l" source-original)
-;; TODO: Use phan's severity level to choose between warning and info. Include that in the lines printed by phan_client.
+  :command ("phan_client" "-l" source-original "-f" source)
+;; Alternately, use the below :command with the commented out :predicate to only run the check after file save.
+;; :command ("phan_client" "-l" source-original)
+
   :error-patterns
   ((warning line-start (or "Parse" "Fatal" "syntax" "Phan") " error" (any ":" ",") " " (message) " in " (file-name) " on line " line line-end))
   :modes (php-mode php+-mode)
-;; Since we check the original file, we can only use this phan checker if
-;; the buffer is actually linked to a file, and if it is not modified.
-;; TODO: Work around this by passing the contents of the temporary file and the path to the original file to the daemon through phan_client
-;; TODO: This predicate doesn't work if the previous doesn't have the predicate, or if there is a previous checker.
-  :predicate flycheck-buffer-saved-p
+; We would work around this by passing the contents of the temporary file and the path to the original file to the daemon through phan_client
+; However, if the "-f" option isn't used (and only source-original was used), we would have to limit this to when the buffer was saved(flycheck-buffer-saved-p)
+;  :predicate flycheck-buffer-saved-p
   )
 (flycheck-add-next-checker 'php '(warning . php-phanclient))
 (add-to-list 'flycheck-checkers 'php-phanclient)


### PR DESCRIPTION
Worked around the previous limitation.
Phan needs to know the path in the original project to work properly,
which is why both source and source-original are provided.